### PR TITLE
feat: configure frontend backend connection

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_BACKEND_URL=http://localhost:5000

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,3 +1,28 @@
+## Local Development
+
+1. Start the backend Flask server (from the repository root):
+
+   ```bash
+   cd backend
+   python backend_service.py
+   ```
+
+2. Configure the frontend to point at the backend by copying the example environment file:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+   Adjust `VITE_BACKEND_URL` in `.env` if your backend runs on a different URL.
+
+3. Start the frontend dev server:
+
+   ```bash
+   npm run dev
+   ```
+
+The application will call the backend's `/process_text` endpoint when you click **Process Text**.
+
 # React + TypeScript + Vite
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,7 +37,8 @@ const App: React.FC = () => {
     const [textColor, setTextColor] = useState<string>('#1F2937');
 
     // Backend URL where your Flask/FastAPI application will run
-    const BACKEND_URL: string = 'http://localhost:5000';
+    // Can be configured via Vite's environment variable `VITE_BACKEND_URL`
+    const BACKEND_URL: string = import.meta.env.VITE_BACKEND_URL || 'http://localhost:5000';
 
     // Firebase initialization useEffect removed
 
@@ -296,7 +297,7 @@ const App: React.FC = () => {
                             ref={(el: ReactQuill | null) => { // Corrected type for ref
                                 if (el && el.editor) {
                                     const editor = el.editor;
-                                    const quillElement = editor.container.querySelector('.ql-editor');
+                                    const quillElement = editor.container.querySelector('.ql-editor') as HTMLElement | null;
                                     if (quillElement) {
                                         quillElement.style.fontSize = `${fontSize}px`;
                                         quillElement.style.lineHeight = String(lineHeight);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.tsx'; // Ensure this path is correct for your App component
 import './index.css'; // Your main CSS file with Tailwind directives


### PR DESCRIPTION
## Summary
- allow configuring backend URL via VITE_BACKEND_URL and document setup
- fix Quill editor typing and remove unused React import to build cleanly

## Testing
- `npm run lint`
- `npm run build`
- `python -m py_compile backend/backend_service.py`