### PR TITLE
fix: load tailwind on frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,6 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=OpenDyslexic&display=swap" rel="stylesheet" />
     <!-- Add other fonts if you want them specifically loaded for Quill to use -->
     <link href="https://fonts.googleapis.com/css2?family=Arial&family=Verdana&family=Calibri&family=Comic+Sans+MS&display=swap" rel="stylesheet" />
+    <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,13 @@
+import tailwindcss from '@tailwindcss/postcss';
+import autoprefixer from 'autoprefixer';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default {
+  plugins: [
+    tailwindcss({ config: join(__dirname, 'tailwind.config.js') }),
+    autoprefixer(),
+  ],
+};

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,13 @@
+import colors from 'tailwindcss/colors';
+
+export default {
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    colors: {
+      ...colors,
+    },
+    extend: {},
+  },
+  safelist: ['bg-gray-100','bg-white','text-gray-600','text-gray-800'],
+  plugins: [],
+};

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,12 +1,7 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import tailwindcss from '@tailwindcss/vite'
-
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(),
-        tailwindcss(),
-
-  ],
+  plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- ensure Tailwind CSS loads on the client by referencing the CDN script
- add Tailwind and PostCSS config to support local builds

## Testing
- `npm run build`
- `npm run lint`